### PR TITLE
EF-164 Fix warning for ansible 2.3

### DIFF
--- a/tasks/alarms.yml
+++ b/tasks/alarms.yml
@@ -14,4 +14,4 @@
     description: "Instance status check failed"
     dimensions: { 'InstanceId': "{{ ansible_ec2_instance_id }}" }
     alarm_actions: "{{ aws_alarms_actions }}"
-  when: "{{ aws_enable_statuscheck_alarm }}"
+  when: aws_enable_statuscheck_alarm


### PR DESCRIPTION
### What has been done

- Fixed the warnings thrown by ansible:

>  [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ aws_enable_statuscheck_alarm }}

### How to test
- You might want to combine this with: https://github.com/Enrise/stichting-liab/pull/41
- Make sure you have ansible 2.3
- Apply the changes manually for LIAB and provision staging
- Check for errors/warnings

### ToDo
- Tag a new version
- Update LIAB to use the new version
